### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ function forwardPropagation(model, xTrain, yTrain) {
   const predictions = [];
   let cost = 0;
   for (let i = 0; i < m; i += 1) {
-    const prediction = nanoNeuron.predict(xTrain[i]);
+    const prediction = model.predict(xTrain[i]);
     cost += predictionCost(yTrain[i], prediction);
     predictions.push(prediction);
   }
@@ -231,8 +231,8 @@ function trainModel({model, epochs, alpha, xTrain, yTrain}) {
     const [dW, dB] = backwardPropagation(predictions, xTrain, yTrain);
   
     // Adjust our NanoNeuron parameters to increase accuracy of our model predictions.
-    nanoNeuron.w += alpha * dW;
-    nanoNeuron.b += alpha * dB;
+    model.w += alpha * dW;
+    model.b += alpha * dB;
   }
 
   return costHistory;


### PR DESCRIPTION
Fix typo in the code examples where `nanoNeuron` variable was used instead of `model` variable inside the functions. I think it's more clear now since the NN instance is passed into the functions as `model` argument.